### PR TITLE
:bug: Fix generation of TollesLawsonCompensator's 16-item components

### DIFF
--- a/deinterf/compensator.py
+++ b/deinterf/compensator.py
@@ -99,7 +99,7 @@ class TollesLawsonCompensator:
             scaling_factor * cos_x * cos_x,
             scaling_factor * cos_x * cos_y,
             scaling_factor * cos_x * cos_z,
-            scaling_factor * cos_y * cos_y,
+            scaling_factor * cos_y * cos_y,  # removed in 16-item version
             scaling_factor * cos_y * cos_z,
             scaling_factor * cos_z * cos_z,
         ]
@@ -109,7 +109,7 @@ class TollesLawsonCompensator:
             scaling_factor * cos_x * cos_y_dot,
             scaling_factor * cos_x * cos_z_dot,
             scaling_factor * cos_y * cos_x_dot,
-            scaling_factor * cos_y * cos_y_dot,
+            scaling_factor * cos_y * cos_y_dot,  # removed in 16-item version
             scaling_factor * cos_y * cos_z_dot,
             scaling_factor * cos_z * cos_x_dot,
             scaling_factor * cos_z * cos_y_dot,
@@ -117,16 +117,8 @@ class TollesLawsonCompensator:
         ]
 
         if self._coefficients_num == 16:
-            induced_items = [
-                item
-                for item in induced_items
-                if item is not scaling_factor * cos_y * cos_y
-            ]
-            eddy_items = [
-                item
-                for item in eddy_items
-                if item is not scaling_factor * cos_y * cos_y_dot
-            ]
+            del induced_items[len(induced_items) // 2]
+            del eddy_items[len(eddy_items) // 2]
 
         return permanent_items, induced_items, eddy_items
 


### PR DESCRIPTION
Thanks for your awesome work!

This PR fixes ```TollesLawsonCompensator._compute_directional_cosine_components``` to correctly remove redundent items when **_coefficients_num_** is specified to 16. This bug is probably due to the refactoring in [20b658](https://github.com/dorian-li/deinterf/commit/20b6588e08d50bace6a5eb68de7fa87a92446a58?diff=split&w=0#diff-9321b87765cea8c98557763f08a325d75bef228f49c415fa31311febc2292932L117-L119).

Please let me know if any changes are required.