### PR TITLE
Fixes subclasses of `DataNDArray` being incompatible within `ufunc`s

### DIFF
--- a/deinterf/utils/data_ioc/_data_ndarray.py
+++ b/deinterf/utils/data_ioc/_data_ndarray.py
@@ -35,7 +35,8 @@ class DataNDArray(np.ndarray, IndexedData):
         inputs = tuple(np.asarray(inp) if isinstance(inp, typ) else inp for inp in inputs)
         if out is not None:
             out = tuple(np.asarray(o) if isinstance(o, typ) else o for o in out)
-        ret = super().__array_ufunc__(ufunc, method, *inputs, out=out, **kwargs)
+
+        ret = getattr(ufunc, method)(*inputs, out=out, **kwargs)
 
         if ret is NotImplemented:
             return NotImplemented


### PR DESCRIPTION
Current implementation requires `ufunc`s operands to be same subclass of `DataNDArray`, otherwise a NotImplemented will be returened. 

This PR fixes this issue.